### PR TITLE
Merge: 알림 시스템 도메인 모델(Entity, Enum) 초기 구축

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/entity/BaseTimeEntity.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/entity/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.LiveKlass.LiveKlass.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
@@ -1,0 +1,43 @@
+package com.LiveKlass.LiveKlass.entity;
+
+import com.LiveKlass.LiveKlass.enums.NotificationChannel;
+import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import com.LiveKlass.LiveKlass.enums.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String eventId;
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationChannel channel;
+
+    public void updateStatus(NotificationStatus status) {
+        this.status = status;
+    }
+
+    @Builder
+    public Notification(String eventId, Long userId, NotificationType type, NotificationStatus status, NotificationChannel channel) {
+        this.eventId = eventId;
+        this.userId = userId;
+        this.type = type;
+        this.status = status;
+        this.channel = channel;
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationChannel.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationChannel.java
@@ -1,0 +1,5 @@
+package com.LiveKlass.LiveKlass.enums;
+
+public enum NotificationChannel {
+    EMAIL, IN_APP
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationStatus.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.LiveKlass.LiveKlass.enums;
+
+public enum NotificationStatus {
+    PENDING, SUCCESS, FAILED
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationType.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/enums/NotificationType.java
@@ -1,0 +1,8 @@
+package com.LiveKlass.LiveKlass.enums;
+
+public enum NotificationType {
+    COURSE_ENROLLED,
+    LECTURE_REMIND,
+    PAYMENT_CONFIRMED,
+    CANCEL_PROCESSED
+}


### PR DESCRIPTION
##  주요 작업 내용
### 1. 도메인 엔티티 (Entity)
- **BaseTimeEntity**: 모든 엔티티의 생성 시간을 자동 관리 (Auditing)
- **Notification**: 알림의 메인 상태와 비즈니스 키(`eventId`)를 관리하는 핵심 엔티티

### 2. 공통 타입 (Enum)
- **NotificationStatus**: 알림의 생명주기 관리 (`PENDING`, `SUCCESS`, `FAILED`)
- **NotificationType**: 알림의 성격 분류 (`COURSE_ENROLLED`, `LECTURE_REMIND` 등) - **향후 이 타입을 기반으로 메시지를 동적 생성할 예정**
- **NotificationChannel**: 발송 매체 정의 (`EMAIL`, `IN_APP`)

## 체크리스트
- [x] 엔티티 매핑 및 테이블 생성 확인 (JPA/Hibernate)
- [x] `@Enumerated(EnumType.STRING)` 적용 여부 확인
- [x] Builder 패턴을 통한 객체 생성 로직 확인