### PR TITLE
Merge: 알림 발송 요청 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application.yml ###
+application.yml

--- a/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
@@ -1,0 +1,24 @@
+package com.LiveKlass.LiveKlass.controller;
+
+import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
+import com.LiveKlass.LiveKlass.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping
+    public ResponseEntity<String> createNotification(@RequestBody NotificationRequest request) {
+        notificationService.registerNotification(request);
+        return ResponseEntity.ok("알림 요청이 정상적으로 접수되었습니다.");
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/dto/request/NotificationRequest.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/request/NotificationRequest.java
@@ -1,0 +1,19 @@
+package com.LiveKlass.LiveKlass.dto.request;
+
+import com.LiveKlass.LiveKlass.enums.NotificationChannel;
+import com.LiveKlass.LiveKlass.enums.NotificationType;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NotificationRequest {
+
+    private Long userId;
+    private NotificationType type;
+    private String eventId;
+    private List<NotificationChannel> channels;
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.LiveKlass.LiveKlass.repository;
+
+import com.LiveKlass.LiveKlass.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
@@ -1,0 +1,33 @@
+package com.LiveKlass.LiveKlass.service;
+
+import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
+import com.LiveKlass.LiveKlass.entity.Notification;
+import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import com.LiveKlass.LiveKlass.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void registerNotification(NotificationRequest request) {
+        List<Notification> notifications = request.getChannels().stream()
+                .map(channel -> Notification.builder()
+                        .userId(request.getUserId())
+                        .type(request.getType())
+                        .eventId(request.getEventId())
+                        .channel(channel)
+                        .status(NotificationStatus.PENDING)
+                        .build())
+                .toList();
+
+        notificationRepository.saveAll(notifications);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=LiveKlass


### PR DESCRIPTION
## 주요 작업 내용
### 1. 도메인 로직 (Service)
다중 채널 지원: List<NotificationChannel>을 순회하며 채널별 독립적인 알림 엔티티를 생성하여 저장 (saveAll 활용)
상태 초기화: 모든 알림 요청의 초기 상태를 PENDING으로 설정하여 비동기 처리 기반 마련

### 2. API 설계 (Controller & DTO)
리소스 중심 엔드포인트: /notifications (POST) 경로를 사용 설계 적용
비동기 응답 표준: 요청 접수 시 202 Accepted 상태 코드를 반환하여 "즉시 발송이 아닌 접수 완료" 상태를 명확히 전달

## 체크리스트
- [x] 엔드포인트 경로: /notifications로 POST 요청이 정상적으로 도달하는가?
- [x] 다중 채널 저장: 입력된 채널 개수만큼 DB에 개별 데이터(Row)가 생성되는가?
- [x] 202 Accepted: 성공 시 적절한 HTTP 상태 코드와 메시지가 반환되는가?
