### PR TITLE
Merge: 특정 알림 상태 조회 구현

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/LiveKlassApplication.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/LiveKlassApplication.java
@@ -2,7 +2,9 @@ package com.LiveKlass.LiveKlass;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LiveKlassApplication {
 

--- a/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
@@ -1,13 +1,11 @@
 package com.LiveKlass.LiveKlass.controller;
 
 import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
+import com.LiveKlass.LiveKlass.dto.response.NotificationResponse;
 import com.LiveKlass.LiveKlass.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/notifications")
@@ -20,5 +18,11 @@ public class NotificationController {
     public ResponseEntity<String> createNotification(@RequestBody NotificationRequest request) {
         notificationService.registerNotification(request);
         return ResponseEntity.ok("알림 요청이 정상적으로 접수되었습니다.");
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NotificationResponse> getNotification(@PathVariable Long id) {
+        NotificationResponse response = notificationService.getNotificationStatus(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
@@ -1,0 +1,21 @@
+package com.LiveKlass.LiveKlass.dto.response;
+
+import com.LiveKlass.LiveKlass.enums.NotificationChannel;
+import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class NotificationResponse {
+
+    private Long id;
+    private String eventId;
+    private NotificationStatus status;
+    private NotificationChannel channel;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
@@ -1,8 +1,11 @@
 package com.LiveKlass.LiveKlass.service;
 
 import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
+import com.LiveKlass.LiveKlass.dto.response.NotificationResponse;
 import com.LiveKlass.LiveKlass.entity.Notification;
 import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import com.LiveKlass.LiveKlass.exception.BusinessException;
+import com.LiveKlass.LiveKlass.exception.ErrorCode;
 import com.LiveKlass.LiveKlass.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,5 +32,19 @@ public class NotificationService {
                 .toList();
 
         notificationRepository.saveAll(notifications);
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationResponse getNotificationStatus(Long id) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .eventId(notification.getEventId())
+                .status(notification.getStatus())
+                .channel(notification.getChannel())
+                .createdAt(notification.getCreatedAt())
+                .build();
     }
 }


### PR DESCRIPTION
##주요 작업 내용
### 1. 조회 기능 (API)
리소스 기반 엔드포인트: /notifications/{id} (GET) 경로를 통해 특정 알림의 세부 정보 요청 가능
비동기 상태 확인: 생성된 알림이 현재 어떤 단계(PENDING, SUCCESS, FAILED)에 있는지 실시간 조회 지원

### 2. 데이터 처리 (DTO & Service)
NotificationResponse: 엔티티를 직접 노출하지 않고 ID, 상태, 채널, 생성 시점만 선별하여 반환하는 응답 객체 구현
예외 처리 로직: 존재하지 않는 알림 ID로 요청할 경우 명확한 에러 상황 전달 및 예외 발생
읽기 전용 트랜잭션: @Transactional(readOnly = true)를 적용하여 데이터 정합성 유지 및 조회 성능 최적화

체크리스트
- [x] Path Variable 매핑: URL의 {id} 값이 서비스 로직에 정확히 전달되는가?
- [x] 데이터 변환: 엔티티 필드가 NotificationResponse DTO로 누락 없이 매핑되는가?
- [x] NULL 처리: 존재하지 않는 ID 조회 시 적절한 예외 응답이 발생하는가?
- [x] 불필요한 정보 차단: 보안 및 설계 원칙에 따라 민감한 내부 필드는 응답에서 제외했는가?