### PR TITLE
Merge: 알림 목록 조회 및 단건 상세 조회 시 읽음 상태 갱신 기능 구현

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/notifications")
 @RequiredArgsConstructor
@@ -24,5 +26,11 @@ public class NotificationController {
     public ResponseEntity<NotificationResponse> getNotification(@PathVariable Long id) {
         NotificationResponse response = notificationService.getNotificationStatus(id);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> getUserNotifications(@RequestParam Long userId) {
+        List<NotificationResponse> responses = notificationService.getUserNotifications(userId);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.LiveKlass.LiveKlass.dto.response;
 
+import com.LiveKlass.LiveKlass.entity.Notification;
 import com.LiveKlass.LiveKlass.enums.NotificationChannel;
 import com.LiveKlass.LiveKlass.enums.NotificationStatus;
 import lombok.AllArgsConstructor;
@@ -18,4 +19,16 @@ public class NotificationResponse {
     private NotificationStatus status;
     private NotificationChannel channel;
     private LocalDateTime createdAt;
+    private boolean isRead;
+
+    public static NotificationResponse convertToResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .eventId(notification.getEventId())
+                .status(notification.getStatus())
+                .channel(notification.getChannel())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
@@ -28,16 +28,24 @@ public class Notification extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private NotificationChannel channel;
 
-    public void updateStatus(NotificationStatus status) {
-        this.status = status;
-    }
+    private boolean isRead = false;
 
     @Builder
-    public Notification(String eventId, Long userId, NotificationType type, NotificationStatus status, NotificationChannel channel) {
+    public Notification(String eventId, Long userId, NotificationType type, NotificationStatus status, NotificationChannel channel, boolean isRead) {
         this.eventId = eventId;
         this.userId = userId;
         this.type = type;
         this.status = status;
         this.channel = channel;
+        this.isRead = isRead;
     }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public void updateStatus(NotificationStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
@@ -3,5 +3,8 @@ package com.LiveKlass.LiveKlass.repository;
 import com.LiveKlass.LiveKlass.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
@@ -34,17 +34,22 @@ public class NotificationService {
         notificationRepository.saveAll(notifications);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public NotificationResponse getNotificationStatus(Long id) {
         Notification notification = notificationRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-        return NotificationResponse.builder()
-                .id(notification.getId())
-                .eventId(notification.getEventId())
-                .status(notification.getStatus())
-                .channel(notification.getChannel())
-                .createdAt(notification.getCreatedAt())
-                .build();
+        notification.markAsRead();
+
+        return NotificationResponse.convertToResponse(notification);
     }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getUserNotifications(Long userId) {
+        return notificationRepository.findAllByUserId(userId).stream()
+                .map(NotificationResponse::convertToResponse)
+                .toList();
+    }
+
+
 }


### PR DESCRIPTION
##주요 작업 내용
### 1. 비즈니스 로직
상태 갱신: 사용자가 특정 알림을 확인(GET /notifications/{id})하는 시점에 읽음 처리하도록 변경
목록 조회: 특정 사용자의 모든 알림 조회

체크리스트
- [x] 상태 변화 확인: /notifications/{id} 호출 후 해당 알림의 isRead 값이 true로 바뀌는가?
- [x] 목록 조회 영향: /notifications?userId={userId} 호출 시에는 isRead 상태가 변하지 않는가?
- [x] 예외 처리: 존재하지 않는 알림 조회 시 ErrorCode.NOTIFICATION_NOT_FOUND가 정상 작동하는가?
- [x] 응답 필드: 조회 결과에 변경된 isRead 상태가 즉시 반영되어 반환되는가?