### PR TITLE
Merge: 사용자 알림 목록 조회 필터링 기능 구현

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
@@ -29,8 +29,8 @@ public class NotificationController {
     }
 
     @GetMapping
-    public ResponseEntity<List<NotificationResponse>> getUserNotifications(@RequestParam Long userId) {
-        List<NotificationResponse> responses = notificationService.getUserNotifications(userId);
+    public ResponseEntity<List<NotificationResponse>> getUserNotifications(@RequestParam Long userId, @RequestParam(required = false) Boolean isRead) {
+        List<NotificationResponse> responses = notificationService.getUserNotifications(userId, isRead);
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
     List<Notification> findAllByUserId(Long userId);
+    List<Notification> findAllByUserIdAndIsRead(Long userId, boolean isRead);
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
@@ -45,11 +45,17 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<NotificationResponse> getUserNotifications(Long userId) {
-        return notificationRepository.findAllByUserId(userId).stream()
+    public List<NotificationResponse> getUserNotifications(Long userId, Boolean isRead) {
+        List<Notification> notifications;
+
+        if (isRead == null) {
+            notifications = notificationRepository.findAllByUserId(userId);
+        } else {
+            notifications = notificationRepository.findAllByUserIdAndIsRead(userId, isRead);
+        }
+
+        return notifications.stream()
                 .map(NotificationResponse::convertToResponse)
                 .toList();
     }
-
-
 }


### PR DESCRIPTION
## 주요 작업 내용
### 1. API 기능 확장
동적 필터링: GET /notifications?userId=1&isRead=false와 같이 쿼리 파라미터를 통해 읽지 않은 알림만 선별 조회 가능
유연한 파라미터: isRead 파라미터를 선택적(optional)으로 설계하여 기존의 전체 조회 기능과 하위 호환성 유지

### 2. 쿼리 최적화 (Repository)
조건부 조회: JPA Method Name 전략을 사용하여 userId와 isRead 조건이 결합된 최적화된 SELECT 쿼리 수행

체크리스트
- [x] 필터 작동 확인: isRead=true일 때 읽은 알림만, false일 때 안 읽은 알림만 반환되는가?
- [x] 전체 조회 확인: isRead 파라미터가 없을 때 모든 알림이 반환되는가?
- [x] 데이터 정합성: 조회된 목록의 isRead 값이 요청한 필터 값과 일치하는가?