### PR TITLE
Merge: 알림 처리 상태(status) 단독 조회 기능 구현

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.LiveKlass.LiveKlass.controller;
 
 import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
 import com.LiveKlass.LiveKlass.dto.response.NotificationResponse;
+import com.LiveKlass.LiveKlass.dto.response.NotificationStatusResponse;
 import com.LiveKlass.LiveKlass.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class NotificationController {
 
     @GetMapping("/{id}")
     public ResponseEntity<NotificationResponse> getNotification(@PathVariable Long id) {
-        NotificationResponse response = notificationService.getNotificationStatus(id);
+        NotificationResponse response = notificationService.getNotification(id);
         return ResponseEntity.ok(response);
     }
 
@@ -32,5 +33,11 @@ public class NotificationController {
     public ResponseEntity<List<NotificationResponse>> getUserNotifications(@RequestParam Long userId, @RequestParam(required = false) Boolean isRead) {
         List<NotificationResponse> responses = notificationService.getUserNotifications(userId, isRead);
         return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<NotificationStatusResponse> getNotificationStatusOnly(@PathVariable Long id) {
+        NotificationStatusResponse response = notificationService.getOnlyStatus(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationStatusResponse.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationStatusResponse.java
@@ -1,0 +1,15 @@
+package com.LiveKlass.LiveKlass.dto.response;
+
+import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class NotificationStatusResponse {
+
+    private Long id;
+    private NotificationStatus status;
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.LiveKlass.LiveKlass.service;
 
 import com.LiveKlass.LiveKlass.dto.request.NotificationRequest;
 import com.LiveKlass.LiveKlass.dto.response.NotificationResponse;
+import com.LiveKlass.LiveKlass.dto.response.NotificationStatusResponse;
 import com.LiveKlass.LiveKlass.entity.Notification;
 import com.LiveKlass.LiveKlass.enums.NotificationStatus;
 import com.LiveKlass.LiveKlass.exception.BusinessException;
@@ -35,7 +36,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public NotificationResponse getNotificationStatus(Long id) {
+    public NotificationResponse getNotification(Long id) {
         Notification notification = notificationRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
@@ -57,5 +58,16 @@ public class NotificationService {
         return notifications.stream()
                 .map(NotificationResponse::convertToResponse)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationStatusResponse getOnlyStatus(Long id) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        return NotificationStatusResponse.builder()
+                .id(notification.getId())
+                .status(notification.getStatus())
+                .build();
     }
 }


### PR DESCRIPTION
## 주요 작업 내용
### 1. 경량 조회 API 
전용 엔드포인트: GET /notifications/{id}/status 경로를 통해 알림의 처리 현황만 빠르게 조회할 수 있도록 분리

### 2. 효율적인 응답
최소 데이터 반환: NotificationStatusResponse를 통해 ID와 status만 반환함

## 체크리스트
- [x] 경로 구분: /notifications/{id}(상세/읽음처리)와 /notifications/{id}/status(단순상태)가 명확히 구분되는가?
- [x] 상태 값 확인: PENDING, SUCCESS, FAILED 중 현재 DB의 값이 정확히 반환되는가?
- [x] 무상태 유지: 이 API 호출 후에도 알림의 isRead 상태가 변하지 않고 그대로 유지되는가?
- [x] 예외 처리: 잘못된 ID 요청 시 ErrorCode.NOTIFICATION_NOT_FOUND에 따른 에러 응답이 나가는가?