### PR TITLE
Merge: RabbitMQ 연동 및 DLQ 기반의 안정적인 메시지 전달 아키텍처 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/LiveKlass/LiveKlass/dto/NotificationMessage.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/NotificationMessage.java
@@ -1,0 +1,3 @@
+package com.LiveKlass.LiveKlass.dto;
+
+public record NotificationMessage(Long notificationId) {}

--- a/src/main/java/com/LiveKlass/LiveKlass/enums/OutboxStatus.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/enums/OutboxStatus.java
@@ -1,5 +1,5 @@
 package com.LiveKlass.LiveKlass.enums;
 
 public enum OutboxStatus {
-    PENDING, LOCKED, PUBLISHED
+    PENDING, LOCKED, IN_QUEUE, PUBLISHED
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/exception/ErrorCode.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     METHOD_NOT_ALLOWED(405, "C002", "허용되지 않은 메소드입니다."),
     INTERNAL_SERVER_ERROR(500, "C003", "서버 내부 오류입니다."),
 
-    NOTIFICATION_NOT_FOUND(404, "N001", "존재하지 않는 알림입니다.");
+    NOTIFICATION_NOT_FOUND(404, "N001", "존재하지 않는 알림입니다."),
+    OUTBOX_NOT_FOUND(500, "N002", "알림에 대한 Outbox를 찾을 수 없습니다."),
+    NOTIFICATION_SEND_FAILED(500, "N003", "알림 전송에 실패했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/LiveKlass/LiveKlass/global/DLQConsumer.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/DLQConsumer.java
@@ -1,0 +1,20 @@
+package com.LiveKlass.LiveKlass.global;
+
+import com.LiveKlass.LiveKlass.dto.NotificationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DLQConsumer {
+
+    private final OutboxPersistenceService persistenceService;
+
+    @RabbitListener(queues = RabbitMQConfig.DLQ_QUEUE)
+    public void handleDead(NotificationMessage message) {
+        persistenceService.handleSendFailure(message.notificationId());
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/global/NotificationConsumer.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/NotificationConsumer.java
@@ -1,0 +1,32 @@
+package com.LiveKlass.LiveKlass.global;
+
+import com.LiveKlass.LiveKlass.dto.NotificationMessage;
+import com.LiveKlass.LiveKlass.exception.BusinessException;
+import com.LiveKlass.LiveKlass.exception.ErrorCode;
+import com.LiveKlass.LiveKlass.global.NotificationItemService.SendResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationConsumer {
+
+    private final NotificationItemService notificationItemService;
+    private final OutboxPersistenceService persistenceService;
+
+    @RabbitListener(queues = RabbitMQConfig.NOTIFICATION_QUEUE)
+    public void consume(NotificationMessage message) {
+        Long notificationId = message.notificationId();
+        SendResult result = notificationItemService.sendSingle(notificationId).join();
+
+        if (result.success()) {
+            persistenceService.onSendSuccess(notificationId);
+        } else {
+            log.warn("[Consumer] 알림 전송 실패 - notificationId={}", notificationId);
+            throw new BusinessException(ErrorCode.NOTIFICATION_SEND_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/global/NotificationItemService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/NotificationItemService.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class NotificationItemService {
 
-
     @Async("notificationExecutor")
     public CompletableFuture<SendResult> sendSingle(Long notificationId) {
         try {

--- a/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
@@ -2,6 +2,8 @@ package com.LiveKlass.LiveKlass.global;
 
 import com.LiveKlass.LiveKlass.entity.NotificationOutbox;
 import com.LiveKlass.LiveKlass.enums.NotificationStatus;
+import com.LiveKlass.LiveKlass.exception.BusinessException;
+import com.LiveKlass.LiveKlass.exception.ErrorCode;
 import com.LiveKlass.LiveKlass.enums.OutboxStatus;
 import com.LiveKlass.LiveKlass.repository.NotificationOutboxRepository;
 import com.LiveKlass.LiveKlass.repository.NotificationRepository;
@@ -32,21 +34,20 @@ public class OutboxPersistenceService {
     }
 
     @Transactional
-    public void markSkipped(List<Long> outboxIds) {
+    public void markInQueue(List<Long> outboxIds) {
+        outboxRepository.updateStatus(outboxIds, OutboxStatus.IN_QUEUE);
+    }
+
+    @Transactional
+    public void markPublished(List<Long> outboxIds) {
         outboxRepository.markAsPublished(outboxIds, OutboxStatus.PUBLISHED);
     }
 
     @Transactional
-    public void applyResults(List<Long> successNotifIds, List<Long> successOutboxIds,
-                             List<NotificationOutbox> failedOutboxes) {
-        if (!successNotifIds.isEmpty()) {
-            notificationRepository.updateStatusByIds(successNotifIds, NotificationStatus.SUCCESS);
-            outboxRepository.markAsPublished(successOutboxIds, OutboxStatus.PUBLISHED);
-        }
-
+    public void applyPublishFailures(List<NotificationOutbox> failedOutboxes) {
         if (failedOutboxes.isEmpty()) return;
 
-        List<Long> retryOutboxIds = new ArrayList<>();
+        List<Long> retryIds = new ArrayList<>();
         List<Long> exhaustedNotifIds = new ArrayList<>();
         List<Long> exhaustedOutboxIds = new ArrayList<>();
 
@@ -54,22 +55,39 @@ public class OutboxPersistenceService {
             if (outbox.isExhausted()) {
                 exhaustedNotifIds.add(outbox.getNotificationId());
                 exhaustedOutboxIds.add(outbox.getId());
-                log.warn("[Outbox] 재시도 횟수 소진 - notificationId={}, retryCount={}",
-                        outbox.getNotificationId(), outbox.getRetryCount());
             } else {
-                retryOutboxIds.add(outbox.getId());
-                log.info("[Outbox] 재시도 예약 - notificationId={}, retryCount={}/{}",
-                        outbox.getNotificationId(), outbox.getRetryCount() + 1, NotificationOutbox.MAX_RETRIES);
+                retryIds.add(outbox.getId());
             }
         }
 
-        if (!retryOutboxIds.isEmpty()) {
-            outboxRepository.incrementRetryCount(retryOutboxIds);
-            outboxRepository.updateStatus(retryOutboxIds, OutboxStatus.PENDING);
+        if (!retryIds.isEmpty()) {
+            outboxRepository.incrementRetryCount(retryIds);
+            outboxRepository.updateStatus(retryIds, OutboxStatus.PENDING);
         }
         if (!exhaustedNotifIds.isEmpty()) {
             notificationRepository.updateStatusByIds(exhaustedNotifIds, NotificationStatus.FAILED);
             outboxRepository.markAsPublished(exhaustedOutboxIds, OutboxStatus.PUBLISHED);
+        }
+    }
+
+    @Transactional
+    public void onSendSuccess(Long notificationId) {
+        notificationRepository.updateStatusByIds(List.of(notificationId), NotificationStatus.SUCCESS);
+        outboxRepository.findByNotificationId(notificationId)
+                .ifPresent(o -> outboxRepository.markAsPublished(List.of(o.getId()), OutboxStatus.PUBLISHED));
+    }
+
+    @Transactional
+    public void handleSendFailure(Long notificationId) {
+        NotificationOutbox outbox = outboxRepository.findByNotificationId(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OUTBOX_NOT_FOUND));
+
+        if (outbox.isExhausted()) {
+            notificationRepository.updateStatusByIds(List.of(notificationId), NotificationStatus.FAILED);
+            outboxRepository.markAsPublished(List.of(outbox.getId()), OutboxStatus.PUBLISHED);
+        } else {
+            outboxRepository.incrementRetryCount(List.of(outbox.getId()));
+            outboxRepository.updateStatus(List.of(outbox.getId()), OutboxStatus.PENDING);
         }
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPoller.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPoller.java
@@ -1,79 +1,72 @@
 package com.LiveKlass.LiveKlass.global;
 
+import com.LiveKlass.LiveKlass.dto.NotificationMessage;
+import com.LiveKlass.LiveKlass.entity.Notification;
 import com.LiveKlass.LiveKlass.entity.NotificationOutbox;
 import com.LiveKlass.LiveKlass.enums.NotificationStatus;
-import com.LiveKlass.LiveKlass.global.NotificationItemService.SendResult;
-import com.LiveKlass.LiveKlass.repository.NotificationOutboxRepository;
 import com.LiveKlass.LiveKlass.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class OutboxPoller {
 
-    private final NotificationOutboxRepository outboxRepository;
     private final NotificationRepository notificationRepository;
-    private final NotificationItemService notificationItemService;
     private final OutboxPersistenceService persistenceService;
+    private final RabbitTemplate rabbitTemplate;
 
-    @Scheduled(fixedDelay = 5_000)
+    @Scheduled(fixedDelay = 5000)
     public void poll() {
         List<NotificationOutbox> claimed = persistenceService.claimPending();
         if (claimed.isEmpty()) return;
 
-        List<NotificationOutbox> toSend  = new ArrayList<>();
-        List<Long> skipIds = new ArrayList<>();
+        List<Long> inQueueIds = new ArrayList<>();
+        List<Long> skippedIds = new ArrayList<>();
+        List<NotificationOutbox> failedToPublish = new ArrayList<>();
 
         for (NotificationOutbox outbox : claimed) {
-            notificationRepository.findById(outbox.getNotificationId()).ifPresent(n -> {
-                if (n.getStatus() == NotificationStatus.PROCESSING) {
-                    toSend.add(outbox);
-                } else {
-                    log.info("[Outbox] 이미 처리된 알림 스킵 - notificationId={}, status={}",
-                            outbox.getNotificationId(), n.getStatus());
-                    skipIds.add(outbox.getId());
-                }
-            });
-        }
-
-        if (!skipIds.isEmpty()) {
-            persistenceService.markSkipped(skipIds);
-        }
-
-        if (toSend.isEmpty()) return;
-
-        List<CompletableFuture<SendResult>> futures = toSend.stream()
-                .map(o -> notificationItemService.sendSingle(o.getNotificationId()))
-                .toList();
-
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-
-        List<Long> successNotifIds = new ArrayList<>();
-        List<Long> successOutboxIds = new ArrayList<>();
-        List<NotificationOutbox> failedOutboxes = new ArrayList<>();
-
-        for (int i = 0; i < toSend.size(); i++) {
-            SendResult result = futures.get(i).getNow(new SendResult(0L, false));
-            NotificationOutbox outbox = toSend.get(i);
-            if (result.success()) {
-                successNotifIds.add(result.id());
-                successOutboxIds.add(outbox.getId());
-            } else {
-                failedOutboxes.add(outbox);
+            switch (tryPublish(outbox)) {
+                case IN_QUEUE -> inQueueIds.add(outbox.getId());
+                case SKIPPED -> skippedIds.add(outbox.getId());
+                case FAILED -> failedToPublish.add(outbox);
             }
         }
 
-        persistenceService.applyResults(successNotifIds, successOutboxIds, failedOutboxes);
-
-        log.info("[Outbox] 처리 완료 - 성공={}, 실패={} (재시도 대기 포함)",
-                successNotifIds.size(), failedOutboxes.size());
+        if (!inQueueIds.isEmpty()) persistenceService.markInQueue(inQueueIds);
+        if (!skippedIds.isEmpty()) persistenceService.markPublished(skippedIds);
+        if (!failedToPublish.isEmpty()) persistenceService.applyPublishFailures(failedToPublish);
     }
+
+    private PublishResult tryPublish(NotificationOutbox outbox) {
+        Long notificationId = outbox.getNotificationId();
+
+        Notification notification = notificationRepository.findById(notificationId).orElse(null);
+        if (notification == null) {
+            return PublishResult.SKIPPED;
+        }
+        if (notification.getStatus() != NotificationStatus.PROCESSING) {
+            return PublishResult.SKIPPED;
+        }
+
+        try {
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.NOTIFICATION_EXCHANGE,
+                    RabbitMQConfig.NOTIFICATION_KEY,
+                    new NotificationMessage(notificationId)
+            );
+            return PublishResult.IN_QUEUE;
+        } catch (Exception e) {
+            return PublishResult.FAILED;
+        }
+    }
+
+    private enum PublishResult { IN_QUEUE, SKIPPED, FAILED }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/global/RabbitMQConfig.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/RabbitMQConfig.java
@@ -1,0 +1,70 @@
+package com.LiveKlass.LiveKlass.global;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String NOTIFICATION_EXCHANGE = "notification.exchange";
+    public static final String NOTIFICATION_QUEUE = "notification.queue";
+    public static final String NOTIFICATION_KEY = "notification";
+
+    public static final String DLQ_EXCHANGE = "notification.dlq.exchange";
+    public static final String DLQ_QUEUE = "notification.dlq";
+
+    @Bean
+    DirectExchange notificationExchange() {
+        return new DirectExchange(NOTIFICATION_EXCHANGE);
+    }
+
+    @Bean
+    Queue notificationQueue() {
+        return QueueBuilder.durable(NOTIFICATION_QUEUE)
+                .withArgument("x-dead-letter-exchange", DLQ_EXCHANGE)
+                .withArgument("x-dead-letter-routing-key", NOTIFICATION_KEY)
+                .build();
+    }
+
+    @Bean
+    Binding notificationBinding(Queue notificationQueue, DirectExchange notificationExchange) {
+        return BindingBuilder.bind(notificationQueue)
+                .to(notificationExchange)
+                .with(NOTIFICATION_KEY);
+    }
+
+    @Bean
+    DirectExchange dlqExchange() {
+        return new DirectExchange(DLQ_EXCHANGE);
+    }
+
+    @Bean
+    Queue dlqQueue() {
+        return QueueBuilder.durable(DLQ_QUEUE).build();
+    }
+
+    @Bean
+    Binding dlqBinding(Queue dlqQueue, DirectExchange dlqExchange) {
+        return BindingBuilder.bind(dlqQueue)
+                .to(dlqExchange)
+                .with(NOTIFICATION_KEY);
+    }
+
+    @Bean
+    MessageConverter messageConverter() {
+        return new JacksonJsonMessageConverter();
+    }
+
+    @Bean
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                  MessageConverter messageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter);
+        return template;
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationOutboxRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationOutboxRepository.java
@@ -8,8 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationOutboxRepository extends JpaRepository<NotificationOutbox, Long> {
+
+    Optional<NotificationOutbox> findByNotificationId(Long notificationId);
 
     @Query(value = "SELECT * FROM notification_outbox WHERE status = 'PENDING' FOR UPDATE SKIP LOCKED",
             nativeQuery = true)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,13 @@
 spring:
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    listener:
+      simple:
+        default-requeue-rejected: false
+
   datasource:
     url: jdbc:mysql://localhost:3306/liveklass?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: root


### PR DESCRIPTION
## 주요 작업 내용
### 1. 메시지 브로커 통합
비동기 메시징: OutboxPoller가 직접 발송하지 않고 RabbitMQ로 메시지를 발행(PUBLISH)하여, 시스템 간 결합도를 낮추고 처리량을 분산함.
상태 세분화: Outbox 상태에 IN_QUEUE를 추가하여 메시지가 브로커로 성공적으로 전달되었는지 추적 가능하도록 개선.

### 2. 신뢰성 보장 아키텍처
Dead Letter Queue (DLQ) 구축: 소비자(Consumer)에서 처리 중 예외 발생 시 메시지가 소멸되지 않고 notification.dlq로 이동하도록 설정.
장애 복구 로직 (DLQConsumer): DLQ에 쌓인 메시지를 감시하여 OutboxPersistenceService를 통해 재시도 횟수를 차감하고 다시 PENDING 상태로 돌려보내는 자동 재시도 루프 완성.

### 3. 메시지 컨슈머 구현 (NotificationConsumer)
멱등성 및 정합성 체크: 메시지를 수신했을 때 Notification의 상태를 확인하고, 실제 발송 성공 시에만 최종적으로 SUCCESS 처리하도록 구현.
예외 전파: 발송 실패 시 비즈니스 예외를 던져 RabbitMQ의 nack(Negative Acknowledgement) 메커니즘이 작동하도록 유도.

### 4. 인프라 설정 최적화 (RabbitMQConfig, application.yml)
Durable Queue/Exchange: 서버 재시작 시에도 메시지가 유실되지 않도록 영속성 설정.
JSON 직렬화: JacksonJsonMessageConverter를 통해 Record 타입의 NotificationMessage를 안정적으로 송수신.

## 메시지 흐름 및 장애 대응 아키텍처
Poller: Outbox 레코드를 읽어 RabbitMQ로 발행 후 상태를 IN_QUEUE로 변경.
Consumer: 메시지 수신 후 실제 발송 시도.
성공 시: Notification SUCCESS, Outbox PUBLISHED 처리.
실패 시: Exception 발생 → RabbitMQ가 메시지를 DLQ로 이동.
DLQ Consumer: 실패한 메시지를 읽어 Outbox retryCount 증가 및 다시 PENDING 처리.
Loop: 1번 과정부터 다시 시작 (최대 재시도 횟수까지 반복).

## 체크리스트
- [x] 메시지 유실 방지: RabbitMQ 연결 장애 시에도 Outbox에 PENDING 데이터가 유지되어 나중에 재처리되는가?
- [x] 무한 루프 방지: DLQ를 통한 재시도가 MAX_RETRIES에 도달하면 최종적으로 FAILED 처리되는가?
- [x] JSON 변환: NotificationMessage 레코드가 직렬화/역직렬화 오류 없이 전달되는가?
- [x] 리소스 관리: default-requeue-rejected: false 설정을 통해 실패한 메시지가 일반 큐에서 무한 재시도되지 않고 바로 DLQ로 가는가?