### PR TITLE
Merge: 알림 최종 실패 시 사유 기록 기능 구현 및 가시성 개선

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/dto/response/NotificationResponse.java
@@ -20,6 +20,7 @@ public class NotificationResponse {
     private NotificationChannel channel;
     private LocalDateTime createdAt;
     private boolean isRead;
+    private String failureReason;
 
     public static NotificationResponse convertToResponse(Notification notification) {
         return NotificationResponse.builder()
@@ -29,6 +30,7 @@ public class NotificationResponse {
                 .channel(notification.getChannel())
                 .isRead(notification.isRead())
                 .createdAt(notification.getCreatedAt())
+                .failureReason(notification.getFailureReason())
                 .build();
     }
 }

--- a/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/entity/Notification.java
@@ -34,6 +34,8 @@ public class Notification extends BaseTimeEntity {
 
     private boolean isRead = false;
 
+    private String failureReason;
+
     @Builder
     public Notification(String eventId, Long userId, NotificationType type, NotificationStatus status, NotificationChannel channel, SendTimeSlot sendTimeSlot, boolean isRead) {
         this.eventId = eventId;

--- a/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
@@ -65,7 +65,9 @@ public class OutboxPersistenceService {
             outboxRepository.updateStatus(retryIds, OutboxStatus.PENDING);
         }
         if (!exhaustedNotifIds.isEmpty()) {
-            notificationRepository.updateStatusByIds(exhaustedNotifIds, NotificationStatus.FAILED);
+            notificationRepository.updateStatusAndReasonByIds(exhaustedNotifIds,
+                    NotificationStatus.FAILED,
+                    "RabbitMQ 발행 재시도 횟수(" + NotificationOutbox.MAX_RETRIES + "회) 소진");
             outboxRepository.markAsPublished(exhaustedOutboxIds, OutboxStatus.PUBLISHED);
         }
     }
@@ -83,7 +85,9 @@ public class OutboxPersistenceService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.OUTBOX_NOT_FOUND));
 
         if (outbox.isExhausted()) {
-            notificationRepository.updateStatusByIds(List.of(notificationId), NotificationStatus.FAILED);
+            notificationRepository.updateStatusAndReasonByIds(List.of(notificationId),
+                    NotificationStatus.FAILED,
+                    "알림 전송 재시도 횟수(" + NotificationOutbox.MAX_RETRIES + "회) 소진");
             outboxRepository.markAsPublished(List.of(outbox.getId()), OutboxStatus.PUBLISHED);
         } else {
             outboxRepository.incrementRetryCount(List.of(outbox.getId()));

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,7 +17,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findAllBySendTimeSlotAndStatus(SendTimeSlot slot, NotificationStatus notificationStatus);
 
     @Modifying
-    @Transactional
     @Query("UPDATE Notification n SET n.status = :status WHERE n.id IN :ids")
     void updateStatusByIds(@Param("ids") List<Long> ids, @Param("status") NotificationStatus status);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.status = :status, n.failureReason = :reason WHERE n.id IN :ids")
+    void updateStatusAndReasonByIds(@Param("ids") List<Long> ids,
+                                    @Param("status") NotificationStatus status,
+                                    @Param("reason") String reason);
 }


### PR DESCRIPTION
## 주요 작업 내용
### 1. 도메인 및 DTO 확장
실패 사유 필드 추가: Notification 엔티티에 failureReason 컬럼을 추가하여 전송 실패 원인을 영속적으로 저장.
API 응답 반영: 알림 상세 조회나 목록 조회 시 사용자가(또는 관리자가) 실패 사유를 확인할 수 있도록 DTO에 필드 추가.

### 2. 재시도 소진 시 사유 기록 로직
RabbitMQ 발행 실패 기록: 메시지 브로커로의 전달 시도가 최대 횟수(MAX_RETRIES)를 초과할 경우, "RabbitMQ 발행 재시도 횟수 소진" 메시지를 기록.
최종 발송 실패 기록: 소비자(Consumer)단에서 실제 외부 전송 시도가 최종 실패했을 때, "알림 전송 재시도 횟수 소진" 메시지를 남기도록 고도화.

### 3. 효율적인 벌크 업데이트
상태 및 사유 일괄 갱신: 다량의 알림이 동시에 실패하는 경우를 대비하여 UPDATE 쿼리 하나로 상태(status)와 사유(failureReason)를 한꺼번에 변경하는 @Modifying 쿼리 추가.

## 체크리스트
- [x] 데이터 보존: failureReason이 DB에 정상적으로 저장되고, 응답 시 누락 없이 전달되는가?