### PR TITLE
[feat] LOCKED 상태 정체(Stuck) 데이터 자동 감지 및 복구 스케줄러 도입

### DIFF
--- a/src/main/java/com/LiveKlass/LiveKlass/entity/NotificationOutbox.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/entity/NotificationOutbox.java
@@ -30,6 +30,8 @@ public class NotificationOutbox {
 
     private LocalDateTime createdAt;
 
+    private LocalDateTime lockedAt;
+
     private LocalDateTime publishedAt;
 
     public static NotificationOutbox create(Long notificationId) {

--- a/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/OutboxPersistenceService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class OutboxPersistenceService {
         if (pending.isEmpty()) return pending;
 
         List<Long> ids = pending.stream().map(NotificationOutbox::getId).toList();
-        outboxRepository.updateStatus(ids, OutboxStatus.LOCKED);
+        outboxRepository.lockWithTimestamp(ids, LocalDateTime.now());
         return pending;
     }
 
@@ -77,6 +78,17 @@ public class OutboxPersistenceService {
         notificationRepository.updateStatusByIds(List.of(notificationId), NotificationStatus.SUCCESS);
         outboxRepository.findByNotificationId(notificationId)
                 .ifPresent(o -> outboxRepository.markAsPublished(List.of(o.getId()), OutboxStatus.PUBLISHED));
+    }
+
+    @Transactional
+    public int recoverStuckLocked(int thresholdMinutes) {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(thresholdMinutes);
+        List<NotificationOutbox> stuck = outboxRepository.findStuckLocked(threshold);
+        if (stuck.isEmpty()) return 0;
+
+        List<Long> stuckIds = stuck.stream().map(NotificationOutbox::getId).toList();
+        outboxRepository.updateStatus(stuckIds, OutboxStatus.PENDING);
+        return stuckIds.size();
     }
 
     @Transactional

--- a/src/main/java/com/LiveKlass/LiveKlass/global/StuckRecoveryScheduler.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/global/StuckRecoveryScheduler.java
@@ -1,0 +1,24 @@
+package com.LiveKlass.LiveKlass.global;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StuckRecoveryScheduler {
+
+    private static final int STUCK_THRESHOLD_MINUTES = 10;
+
+    private final OutboxPersistenceService persistenceService;
+
+    @Scheduled(fixedDelay = 600000)
+    public void recover() {
+        int recovered = persistenceService.recoverStuckLocked(STUCK_THRESHOLD_MINUTES);
+        if (recovered > 0) {
+            log.warn("[Recovery] {}건 복구 완료 → OutboxPoller가 재처리 예정", recovered);
+        }
+    }
+}

--- a/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationOutboxRepository.java
+++ b/src/main/java/com/LiveKlass/LiveKlass/repository/NotificationOutboxRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +22,13 @@ public interface NotificationOutboxRepository extends JpaRepository<Notification
     @Modifying
     @Query("UPDATE NotificationOutbox o SET o.status = :status WHERE o.id IN :ids")
     void updateStatus(@Param("ids") List<Long> ids, @Param("status") OutboxStatus status);
+
+    @Modifying
+    @Query("UPDATE NotificationOutbox o SET o.status = 'LOCKED', o.lockedAt = :lockedAt WHERE o.id IN :ids")
+    void lockWithTimestamp(@Param("ids") List<Long> ids, @Param("lockedAt") LocalDateTime lockedAt);
+
+    @Query("SELECT o FROM NotificationOutbox o WHERE o.status = 'LOCKED' AND o.lockedAt < :threshold")
+    List<NotificationOutbox> findStuckLocked(@Param("threshold") LocalDateTime threshold);
 
     @Modifying
     @Query("UPDATE NotificationOutbox o SET o.status = :status, o.publishedAt = CURRENT_TIMESTAMP WHERE o.id IN :ids")


### PR DESCRIPTION
## 주요 작업 내용
### 1. Outbox 엔티티 잠금 시간 추적
lockedAt 필드 추가: 특정 인스턴스가 처리를 위해 데이터를 점유한 시점을 기록하여, 정체 여부를 판단할 수 있는 기준 지표 마련.

### 2. 정체 데이터 복구 로직 구현
시간 기반 임계치 적용: 현재 시점으로부터 10분(thresholdMinutes) 이상 LOCKED 상태가 유지되는 데이터를 비정상 상태로 간주.
상태 초기화: 정체된 데이터를 다시 PENDING으로 되돌려, 다른 정상적인 인스턴스나 다음 주기의 OutboxPoller가 재처리할 수 있도록 복구.

### 3. 복구 스케줄러 자동화
주기적 감시: 10분(600,000ms)마다 백그라운드에서 복구 로직을 실행하여 시스템 안정성 상시 유지.
운영 로그: 복구 발생 시 WARN 로그를 남겨 시스템 이상 징후를 모니터링할 수 있도록 설계.

##  복구 메커니즘 흐름
인스턴스 A: Outbox 점유 (LOCKED + lockedAt 기록).
장애 발생: 인스턴스 A가 발송 도중 갑자기 종료 (DB에는 LOCKED로 남음).
복구 스케줄러: 10분 후 lockedAt이 임계치를 넘은 데이터를 발견.
복구: 상태를 PENDING으로 변경.
인스턴스 B: PENDING 상태가 된 데이터를 다시 읽어 정상 발송 완료.
